### PR TITLE
Update ADRConn.Model.Firedac.Connection.pas

### DIFF
--- a/Source/ADRConn.Model.Firedac.Connection.pas
+++ b/Source/ADRConn.Model.Firedac.Connection.pas
@@ -125,7 +125,10 @@ procedure TADRConnModelFiredacConnection.CreateDriver;
 begin
   FreeAndNil(FDriver);
   FDriver := TADRConnModelFiredacDriver.GetDriver(FParams);
-  FDriver.VendorLib := FParams.Lib;
+  if ExtractFileName(FParams.Lib).Trim.IsEmpty then
+    FDriver.VendorHome := FParams.Lib
+  else
+    FDriver.VendorLib := FParams.Lib;
 end;
 
 destructor TADRConnModelFiredacConnection.Destroy;


### PR DESCRIPTION
Uploading Lib as VendorHome instead VendorLib
Checks if the Lib is a file, to fill it in  as a VendorLib. If a repository, fill it in as a VendorHome