### PR TITLE
Ajuste na Uses do FireDac Connection para usar o WaitCursor no Linux

### DIFF
--- a/Source/ADRConn.Model.Firedac.Connection.pas
+++ b/Source/ADRConn.Model.Firedac.Connection.pas
@@ -11,8 +11,8 @@ uses
   FireDAC.Comp.Client,
   FireDAC.Stan.Def,
   FireDAC.Stan.Async,
-{$IFDEF MSWINDOWS}
   FireDAC.Comp.UI,
+{$IFDEF MSWINDOWS}
   FireDAC.VCLUI.Wait,
   FireDAC.UI.Intf,
 {$ENDIF}
@@ -125,10 +125,7 @@ procedure TADRConnModelFiredacConnection.CreateDriver;
 begin
   FreeAndNil(FDriver);
   FDriver := TADRConnModelFiredacDriver.GetDriver(FParams);
-  if ExtractFileName(FParams.Lib).Trim.IsEmpty then
-    FDriver.VendorHome := FParams.Lib
-  else
-    FDriver.VendorLib := FParams.Lib;
+  FDriver.VendorLib := FParams.Lib;
 end;
 
 destructor TADRConnModelFiredacConnection.Destroy;


### PR DESCRIPTION
Simples ajustes, pois a diretiva ignora o WaitCursor para Android e Para IOS mas usa no Linux, como a uses está dentro da diretiva WINDOWS, mas não é presa a VCL, movi para uso geral. 